### PR TITLE
Added Timeline UI support for SUCCESS_WITH_WARNINGS status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -267,6 +267,7 @@ const RunStatusTags = React.memo(({rows}: {rows: TimelineRow[]}) => {
     let inProgressCount = 0;
     let failedCount = 0;
     let succeededCount = 0;
+    let warningCount = 0;
     rows.forEach(({runs}) => {
       runs.forEach(({status}) => {
         // Refine `SCHEDULED` out so that our Set checks below pass TypeScript.
@@ -277,12 +278,14 @@ const RunStatusTags = React.memo(({rows}: {rows: TimelineRow[]}) => {
           inProgressCount++;
         } else if (failedStatuses.has(status)) {
           failedCount++;
+        } else if(status === 'SUCCESS_WITH_WARNINGS'){
+          warningCount++;
         } else if (successStatuses.has(status)) {
           succeededCount++;
         }
       });
     });
-    return {inProgressCount, failedCount, succeededCount};
+    return {inProgressCount, failedCount, succeededCount, warningCount};
   }, [rows]);
 
   return <RunStatusTagsWithCounts {...counts} />;
@@ -292,16 +295,21 @@ export const RunStatusTagsWithCounts = ({
   inProgressCount,
   succeededCount,
   failedCount,
+  warningCount,
 }: {
   inProgressCount: number;
   succeededCount: number;
   failedCount: number;
+  warningCount: number;
 }) => {
   const inProgressText =
     inProgressCount === 1 ? '1 run in progress' : `${inProgressCount} runs in progress`;
   const succeededText =
     succeededCount === 1 ? '1 run succeeded' : `${succeededCount} runs succeeded`;
-  const failedText = failedCount === 1 ? '1 run failed' : `${failedCount} runs failed`;
+  const failedText = 
+    failedCount === 1 ? '1 run failed' : `${failedCount} runs failed`;
+  const warningText = 
+    warningCount === 1 ? '1 run succeeded with warnings' : `${warningCount} runs succeeded with warnings`;
 
   return (
     <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
@@ -318,6 +326,11 @@ export const RunStatusTagsWithCounts = ({
       {failedCount > 0 ? (
         <Tooltip content={<StatusSpan>{failedText}</StatusSpan>} placement="top">
           <Tag intent="danger">{failedCount}</Tag>
+        </Tooltip>
+      ) : null}
+      {warningCount > 0 ? (
+        <Tooltip content={<StatusSpan>{warningText}</StatusSpan>} placement="top">
+          <Tag intent="warning">{warningCount}</Tag>
         </Tooltip>
       ) : null}
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
@@ -2,8 +2,9 @@ import {Colors} from '@dagster-io/ui-components';
 
 import {failedStatuses, inProgressStatuses, queuedStatuses, successStatuses} from './RunStatuses';
 import {TimelineRun} from './RunTimelineTypes';
+import { buildAssetCountBySection } from 'shared/search/BuildAssetSearchResults';
 
-type BackgroundStatus = 'inProgress' | 'queued' | 'failed' | 'succeeded' | 'scheduled';
+type BackgroundStatus = 'inProgress' | 'queued' | 'failed' | 'succeeded' | 'scheduled' | 'succeededWithWarnings';
 
 const statusToColor = (status: BackgroundStatus) => {
   switch (status) {
@@ -17,6 +18,8 @@ const statusToColor = (status: BackgroundStatus) => {
       return Colors.accentRed();
     case 'succeeded':
       return Colors.accentGreen();
+    case 'succeededWithWarnings':
+      return Colors.accentYellow();
   }
 };
 
@@ -27,6 +30,7 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
     inProgress: 0,
     failed: 0,
     succeeded: 0,
+    succeededWithWarnings: 0,
   };
 
   runs.forEach(({status}) => {
@@ -38,6 +42,8 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
       counts.inProgress++;
     } else if (failedStatuses.has(status)) {
       counts.failed++;
+    } else if(status === 'SUCCESS_WITH_WARNINGS'){
+      counts.succeededWithWarnings++;
     } else if (successStatuses.has(status)) {
       counts.succeeded++;
     }
@@ -57,6 +63,8 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
 
   const colors = [
     counts.failed > 0 ? {status: 'failed', pct: (counts.failed * 100) / runCount} : null,
+    counts.succeededWithWarnings > 0
+      ? {status: 'succeededWithWarnings', pct:(counts.succeededWithWarnings * 100)/ runCount} : null,
     counts.succeeded > 0 ? {status: 'succeeded', pct: (counts.succeeded * 100) / runCount} : null,
     counts.inProgress > 0
       ? {status: 'inProgress', pct: (counts.inProgress * 100) / runCount}


### PR DESCRIPTION
## Summary & Motivation
This change adds timeline bar and run count UI support for the 'SUCCESS_WITH_WARNINGS' status by displaying those components in yellow instead of green. The goal is to make runs with warnings visually distinct in the Overview Timeline tab.

## How I Tested These Changes
I used the 'basic_assets_jobs' and 'checks_included_job' and confirmed:
- Timeline bars appear in yellow for the run with 'SUCCESS_WITH_WARNINGS'
- Run count tag also shows up in yellow
- No changes in other statuses

## Changelog
Added: Timeline and run count UI support for `SUCCESS_WITH_WARNINGS` status (yellow indicators)

