### PR TITLE
Added overflow tooltip to Status and increased the font size of Status text to 14px

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
@@ -15,7 +15,7 @@ interface Props {
   tooltipText?: string;
 }
 
-const BaseTagTooltipStyle: React.CSSProperties = {
+export const BaseTagTooltipStyle: React.CSSProperties = {
   fontSize: 12,
   lineHeight: '16px',
   alignItems: 'center',

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -1,4 +1,4 @@
-import {Box, CaptionMono, Colors, Popover, Tag} from '@dagster-io/ui-components';
+import {Box, CaptionMono, Colors, Popover, Tag, BaseTagTooltipStyle} from '@dagster-io/ui-components';
 
 import {RunStats} from './RunStats';
 import {RunStatusIndicator} from './RunStatusDots';
@@ -97,12 +97,32 @@ export const RUN_STATUS_COLORS = {
 
 export const RunStatusTag = (props: {status: RunStatus}) => {
   const {status} = props;
+  const statusString = runStatusToString(status);
   return (
     <Tag intent={statusToIntent(status)}>
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-        <RunStatusIndicator status={status} size={10} />
-        <div>{runStatusToString(status)}</div>
-      </Box>
+      <span
+        data-tooltip={statusString}
+        data-tooltip-style={JSON.stringify({
+          ...BaseTagTooltipStyle,
+          backgroundColor: Colors.tooltipBackground(),
+          color: Colors.tooltipText(),
+        })}
+        style={{
+          display: 'inline-block',   
+          maxWidth: 96,              
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          verticalAlign: 'middle',
+        }}
+      >
+        <span style={{display: 'inline-block', verticalAlign: 'middle', marginRight: 4}}>
+          <RunStatusIndicator status={status} size={10} />
+        </span>
+        <span style={{verticalAlign: 'middle'}}>
+          {statusString}
+        </span>
+      </span>
     </Tag>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -104,6 +104,7 @@ export const RunStatusTag = (props: {status: RunStatus}) => {
         data-tooltip={statusString}
         data-tooltip-style={JSON.stringify({
           ...BaseTagTooltipStyle,
+          fontSize: 14,
           backgroundColor: Colors.tooltipBackground(),
           color: Colors.tooltipText(),
         })}
@@ -119,7 +120,7 @@ export const RunStatusTag = (props: {status: RunStatus}) => {
         <span style={{display: 'inline-block', verticalAlign: 'middle', marginRight: 4}}>
           <RunStatusIndicator status={status} size={10} />
         </span>
-        <span style={{verticalAlign: 'middle'}}>
+        <span style={{verticalAlign: 'middle', fontSize: 14}}>
           {statusString}
         </span>
       </span>


### PR DESCRIPTION
## Summary & Motivation
This change adds overflow tooltip to the Status text and increases status text size to 14px for better readability. 

## Changes
-Use BaseTagTooltipStyle so that the tooltip style matches the Runs details page.
-Increased the status text size from 12px to 14px 

## How I Tested These Changes
I used the 'basic_assets_jobs' + 'checks_included_job' as well as my custom test files and confirmed:
-Long statuses truncate and show a tooltip when hovering the icon or text.
-Text reads clearly at 14px; no regressions elsewhere.