### PR TITLE
Add asset check failure ratio with popover to run status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -149,7 +149,7 @@
   "RunActionButtonsTestQuery": "604a93ec19ca72ff504447fb4bae7309f0ae8ab24ec5d7b688d7312d3a00848d",
   "CheckBackfillStatus": "d102ea2a2b731fdbefb7b6762c94aa0a8468b7977c9143cec33a8ea900f2e469",
   "RunsRootQuery": "091646e47ecea81ba4765a3f2cead18880b09ee400d1d7e9dcb6e194ee364e51",
-  "RunsFeedRootQuery": "282e5f8bed5df756b068ef7819c587d6ace1c571ac96b78a1b25f17240acd765",
+  "RunsFeedRootQuery": "b7881e7d7362156df85d720bd3ce800957218cb5c6ffc5b81752fa7528e3d6b0",
   "OngoingRunTimelineQuery": "7437e39dbde776b1bbaa231d1cfdd4611117e72eabd0f8fc9f64d13ec150c82b",
   "CompletedRunTimelineQuery": "1f34f13f13209633691baabedf021000f45052a8cc5499108393013cae3e1f00",
   "FutureTicksQuery": "9b947053273ecaa20ef19df02f0aa8e6f33b8a1628175987670e3c73a350e640",

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -234,7 +234,7 @@ const RunChecksPopoverContent = ({
   }, [evaluations]);
 
   return (
-    <Box padding={12} flex={{direction: 'column', gap: 6}}>
+    <Box padding={12} flex={{direction: 'column', gap: 6}} style={{maxWidth: 420}}>
       <Body2>{summaryText}</Body2>
 
       <Box
@@ -246,9 +246,15 @@ const RunChecksPopoverContent = ({
         }}
       >
         {sorted.map((e) => (
-          <Box key={evaluationKey(e)} flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          <Box
+            key={evaluationKey(e)}
+            flex={{direction: 'row', alignItems: 'center', gap: 8}}
+            style={{minWidth: 0}}
+          >
             {iconForEvaluation(e)}
-            <CaptionMono style={{whiteSpace: 'normal', overflowWrap: 'anywhere'}}>
+            <CaptionMono
+              style={{flex: 1, minWidth: 0, whiteSpace: 'normal', overflowWrap: 'anywhere'}}
+            >
               {e.checkName}
             </CaptionMono>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -1,9 +1,11 @@
-import {Box, CaptionMono, Colors, Popover, Tag} from '@dagster-io/ui-components';
+import {Body2, Box, CaptionMono, Colors, Icon, Popover, Tag} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
 
 import {RunStats} from './RunStats';
 import {RunStatusIndicator} from './RunStatusDots';
 import {assertUnreachable} from '../app/Util';
-import {RunStatus} from '../graphql/types';
+import {AssetCheckSeverity, RunStatus} from '../graphql/types';
+import {RunsFeedTableEntryFragment} from './types/RunsFeedTableEntryFragment.types';
 
 const statusToIntent = (status: RunStatus) => {
   switch (status) {
@@ -127,6 +129,161 @@ export const RunStatusTagWithStats = (props: Props) => {
       usePortal
     >
       <RunStatusTag status={status} />
+    </Popover>
+  );
+};
+
+type RunsFeedEntryRun = Extract<RunsFeedTableEntryFragment, {__typename: 'Run'}>;
+type RunAssetCheckEvaluation = RunsFeedEntryRun['assetCheckEvaluations'][number];
+
+const getRunChecksSummary = (evaluations?: RunAssetCheckEvaluation[] | null) => {
+  if (!evaluations || evaluations.length === 0) {
+    return null;
+  }
+
+  const totalCount = evaluations.length;
+  const failedCount = evaluations.filter((e) => !e.success).length;
+
+  if (failedCount === 0) {
+    return null;
+  }
+
+  const label = `(${failedCount}/${totalCount})`;
+  const summaryText =
+    totalCount === 1
+      ? '1 asset check failed'
+      : `${failedCount} of ${totalCount} asset checks failed`;
+
+  return {evaluations, label, summaryText};
+};
+
+type ChecksTagIntent = 'warning' | 'danger';
+
+const checksTagIntent = (evaluations: RunAssetCheckEvaluation[]): ChecksTagIntent => {
+  const failed = evaluations.filter((e) => !e.success);
+  const hasErrorFailure = failed.some((e) => e.severity === AssetCheckSeverity.ERROR);
+  return hasErrorFailure ? 'danger' : 'warning';
+};
+
+const iconForEvaluation = (e: RunAssetCheckEvaluation) => {
+  if (e.success) {
+    return <Icon name="check_circle" color={Colors.accentGreen()} />;
+  }
+  if (e.severity === AssetCheckSeverity.WARN) {
+    return <Icon name="warning_outline" color={Colors.accentYellow()} />;
+  }
+  return <Icon name="cancel" color={Colors.accentRed()} />;
+};
+
+const evaluationKey = (e: RunAssetCheckEvaluation) => {
+  const assetKeyStr = e.assetKey.path.join('/');
+  return `${e.checkName}-${assetKeyStr}-${e.timestamp}`;
+};
+
+const severityRank = (s: AssetCheckSeverity) => {
+  // Lower number = earlier in list
+  switch (s) {
+    case AssetCheckSeverity.ERROR:
+      return 0;
+    case AssetCheckSeverity.WARN:
+      return 1;
+    default:
+      return 2;
+  }
+};
+
+export const RunChecksTag = ({label, intent}: {label: string; intent: ChecksTagIntent}) => {
+  return (
+    <Tag intent={intent}>
+      <CaptionMono>{label}</CaptionMono>
+    </Tag>
+  );
+};
+
+const RunChecksPopoverContent = ({
+  evaluations,
+  summaryText,
+}: {
+  evaluations: RunAssetCheckEvaluation[];
+  summaryText: string;
+}) => {
+  const sorted = useMemo(() => {
+    return [...evaluations].sort((a, b) => {
+      if (a.success !== b.success) {
+        return a.success ? 1 : -1;
+      }
+
+      if (!a.success && !b.success && a.severity !== b.severity) {
+        return severityRank(a.severity) - severityRank(b.severity);
+      }
+
+      const aAsset = a.assetKey.path.join('/');
+      const bAsset = b.assetKey.path.join('/');
+      const assetCmp = aAsset.localeCompare(bAsset);
+      if (assetCmp !== 0) {
+        return assetCmp;
+      }
+
+      const nameCmp = a.checkName.localeCompare(b.checkName);
+      if (nameCmp !== 0) {
+        return nameCmp;
+      }
+
+      return b.timestamp - a.timestamp;
+    });
+  }, [evaluations]);
+
+  return (
+    <Box padding={12} flex={{direction: 'column', gap: 6}}>
+      <Body2>{summaryText}</Body2>
+
+      <Box
+        flex={{direction: 'column', gap: 6}}
+        style={{
+          maxHeight: 240,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+        }}
+      >
+        {sorted.map((e) => (
+          <Box key={evaluationKey(e)} flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+            {iconForEvaluation(e)}
+            <CaptionMono style={{whiteSpace: 'normal', overflowWrap: 'anywhere'}}>
+              {e.checkName}
+            </CaptionMono>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export const RunChecksTagWithPopover = ({
+  evaluations,
+}: {
+  evaluations?: RunAssetCheckEvaluation[] | null;
+}) => {
+  const summary = getRunChecksSummary(evaluations);
+  if (!summary) {
+    return null;
+  }
+
+  const intent = checksTagIntent(summary.evaluations);
+
+  return (
+    <Popover
+      position="bottom-left"
+      interactionKind="hover"
+      hoverOpenDelay={150}
+      usePortal
+      content={
+        <RunChecksPopoverContent
+          evaluations={summary.evaluations}
+          summaryText={summary.summaryText}
+        />
+      }
+    >
+      <RunChecksTag label={summary.label} intent={intent} />
     </Popover>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -15,7 +15,7 @@ import styled from 'styled-components';
 import {CreatedByTagCell} from './CreatedByTag';
 import {RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
-import {RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
+import {RunChecksTagWithPopover, RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
 import {RunTableTargetHeader} from './RunTableTargetHeader';
 import {DagsterTag} from './RunTag';
 import {RunTags} from './RunTags';
@@ -166,13 +166,14 @@ export const RunsFeedRow = ({
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} repoAddress={repoAddress} />
       </RowCell>
       <RowCell>
-        <div>
           {entry.__typename === 'PartitionBackfill' ? (
             <RunStatusTag status={entry.runStatus} />
           ) : (
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
             <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
-          )}
-        </div>
+            <RunChecksTagWithPopover evaluations={entry.assetCheckEvaluations} />
+          </Box>
+        )}
       </RowCell>
       <RowCell style={{flexDirection: 'column', gap: 4}}>
         <RunTime run={runTime} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTableEntryFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTableEntryFragment.tsx
@@ -39,6 +39,10 @@ export const RUNS_FEED_TABLE_ENTRY_FRAGMENT = gql`
         checkName
         severity
         success
+        timestamp
+        assetKey {
+          path
+        }
       }
       ...RunActionsMenuRunFragment
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTableEntryFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTableEntryFragment.types.ts
@@ -67,6 +67,8 @@ export type RunsFeedTableEntryFragment_Run = {
     checkName: string;
     severity: Types.AssetCheckSeverity;
     success: boolean;
+    timestamp: number;
+    assetKey: {__typename: 'AssetKey'; path: Array<string>};
   }>;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsFeedEntries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsFeedEntries.types.ts
@@ -91,6 +91,8 @@ export type RunsFeedRootQuery = {
                 checkName: string;
                 severity: Types.AssetCheckSeverity;
                 success: boolean;
+                timestamp: number;
+                assetKey: {__typename: 'AssetKey'; path: Array<string>};
               }>;
               tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
               assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
@@ -104,4 +106,4 @@ export type RunsFeedRootQuery = {
       };
 };
 
-export const RunsFeedRootQueryVersion = '282e5f8bed5df756b068ef7819c587d6ace1c571ac96b78a1b25f17240acd765';
+export const RunsFeedRootQueryVersion = 'b7881e7d7362156df85d720bd3ce800957218cb5c6ffc5b81752fa7528e3d6b0';


### PR DESCRIPTION
###  What / Why

Runs can complete while asset checks fail, but the runs list doesn’t clearly surface that. This PR adds a small failure summary in the status cell so users can notice and inspect failed checks directly from the runs feed.

### Changes
- Updated RunsFeedTableEntryFragment and regenerated GraphQL types to include the fields required for rendering asset check status in the runs feed.
- When a run has asset check failures, renders a (failed/total) ratio tag next to the run status.
- Colors the ratio tag pill based on the worst severity among failed checks.
- Adds a popover on the ratio tag that lists failed check evaluations (with icons and identifiers).
- Improves popover usability for longer lists (failed-first ordering, scroll behavior, and text wrapping).

### Files changed
- RunStatusTag.tsx
- RunsFeedRow.tsx
- RunsFeedTableEntryFragment.tsx
- Generated types under src/runs/types/*

### How to test
1. Run the UI locally and open the Runs page.
2. Find/trigger a run with at least one failed asset check.
3. Verify the (failed/total) tag appears and the popover shows the failed checks.
4. Verify runs with no failed checks do not show the tag.

### Notes: 
The popover list is sorted by severity (highest first): ERROR failures appear before WARN failures.
