### PR TITLE
Made the status column width flexible to prevent check result from clipping

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -195,7 +195,7 @@ const severityRank = (s: AssetCheckSeverity) => {
 export const RunChecksTag = ({label, intent}: {label: string; intent: ChecksTagIntent}) => {
   return (
     <Tag intent={intent}>
-      <CaptionMono>{label}</CaptionMono>
+      <CaptionMono style={{whiteSpace: 'nowrap'}}>{label}</CaptionMono>
     </Tag>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -165,11 +165,14 @@ export const RunsFeedRow = ({
       <RowCell>
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} repoAddress={repoAddress} />
       </RowCell>
-      <RowCell>
-          {entry.__typename === 'PartitionBackfill' ? (
-            <RunStatusTag status={entry.runStatus} />
-          ) : (
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+      <RowCell style={{minWidth: 0}}>
+        {entry.__typename === 'PartitionBackfill' ? (
+          <RunStatusTag status={entry.runStatus} />
+        ) : (
+          <Box
+            flex={{direction: 'row', gap: 8, alignItems: 'center', wrap: 'wrap'}}
+            style={{minWidth: 0}}
+          >
             <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
             <RunChecksTagWithPopover evaluations={entry.assetCheckEvaluations} />
           </Box>
@@ -202,7 +205,7 @@ export const RunsFeedRow = ({
 };
 
 const TEMPLATE_COLUMNS =
-  '60px minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 170px 120px 132px';
+  '60px minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1fr) minmax(160px, 1fr) 170px 120px 132px';
 
 export const RunsFeedTableHeader = ({checkbox}: {checkbox: React.ReactNode}) => {
   return (


### PR DESCRIPTION
### Summary
- Fixes an issue where the asset check ratio text (e.g. (2/4)) could be clipped in the Runs Feed Status column.
- Makes the Status column responsive and allows the Status/ratio pills to wrap when the column is narrow.

### Changes
#### 1. RunsFeedRow.tsx: 
- Updated TEMPLATE_COLUMNS to use a flexible Status column (minmax(160px, 1fr)).
- RunsFeedRow.tsx: Allow Status cell contents to wrap (wrap: 'wrap') and add minWidth: 0 to avoid overflow in the grid cell.
#### 2. RunStatusTag.tsx: 
- Prevent ratio text from breaking across lines (whiteSpace: 'nowrap').

### Testing
- Manually verified on the UI that the Status + (failed/total) no longer clips and wraps cleanly when the window is narrow / zoomed.
